### PR TITLE
handling non-zero error code in script

### DIFF
--- a/bin/starexec_run_lia.sh
+++ b/bin/starexec_run_lia.sh
@@ -19,15 +19,15 @@ function spec() {
    local infile=$1
    local outfile=$2
    #echo "Performing query transformation"
-   $LIB/qa $infile -query false -ans -o $resultdir/$f.qa.pl
+   $LIB/qa $infile -query false -ans -o $resultdir/$f.qa.pl || exit 1
    #echo "Computing widening thresholds"
-   $LIB/thresholds1 -prg $resultdir/$f.qa.pl -a -o wut.props
+   $LIB/thresholds1 -prg $resultdir/$f.qa.pl -a -o wut.props || exit 1
    #$PE/props -prg "$resultdir/$f.qa.pl" -l 1 -o wut.props
    
    #echo "Computing convex polyhedron approximation of QA clauses"
-   $LIB/cpascc -prg $resultdir/$f.qa.pl -cex "traceterm.out"  -withwut -wfunc h79 -o $resultdir/$f.qa.cha.pl
+   $LIB/cpascc -prg $resultdir/$f.qa.pl -cex "traceterm.out"  -withwut -wfunc h79 -o $resultdir/$f.qa.cha.pl || exit 1
    #echo "Specialise clauses"
-   $LIB/insertProps -prg $infile -props $resultdir/$f.qa.cha.pl -o $outfile
+   $LIB/insertProps -prg $infile -props $resultdir/$f.qa.cha.pl -o $outfile || exit 1
 }
 
 function checksafe() {
@@ -48,8 +48,8 @@ function checksafe() {
 function pe() {
     local file=$1
     local outfile=$2
-    $PE/props -prg "$file" -l 3 -o "$resultdir/$f.props"
-    $PE/peunf_smt_2 -prg "$file" -entry false -props "$resultdir/$f.props" -type int -o "$resultdir/$f.pe.pl" 
+    $PE/props -prg "$file" -l 3 -o "$resultdir/$f.props" || exit 1
+    $PE/peunf_smt_2 -prg "$file" -entry false -props "$resultdir/$f.props" -type int -o "$resultdir/$f.pe.pl" || exit 1
 }
 
 #=================
@@ -66,13 +66,13 @@ fi
 #echo $1
 # Translation from competition format to Prolog-readable form
 python $SMT2CHC/format.py --split_queries True "$1" > "$resultdir/$f.pl"
-$SMT2CHC/chcNorm "$resultdir/$f.pl" "$resultdir/$f.norm.pl" -int
+$SMT2CHC/chcNorm "$resultdir/$f.pl" "$resultdir/$f.norm.pl" -int || exit 1
 
 prog="$resultdir/$f.norm.pl"
 
 
 #echo "Removal of redundant arguments"
-$LIB/raf "$prog" false "$resultdir/$f.raf.pl"
+$LIB/raf "$prog" false "$resultdir/$f.raf.pl" || exit 1
 prog="$resultdir/$f.raf.pl"
 
 # search for counterexamples first for 15 seconds
@@ -109,7 +109,7 @@ do
 		k=`expr $k \- 1`
 		i=`expr $i \+ 1`
 		#echo "Partial evaluation"
-		pe "$resultdir/$f.sp.pl" "$resultdir/$f.pe.pl"
+		pe "$resultdir/$f.sp.pl" "$resultdir/$f.pe.pl" || exit 1
 		prog="$resultdir/$f.pe.pl"
 		
    fi


### PR DESCRIPTION
It is done for all commands except for `counterExample`, whose error code has some precise meaning (it can be fixed but requires more changes)